### PR TITLE
Format cards

### DIFF
--- a/client/src/components/Payment/AddCardForm.jsx
+++ b/client/src/components/Payment/AddCardForm.jsx
@@ -31,11 +31,18 @@ export default function AddCardForm({loggedInUser})
             }
     },[id])
 
+    const handleCardNumberChange = (e) => {
+        const rawValue = e.target.rawValue;
+        if (rawValue.length <= 16) {
+            setCardNumber(rawValue);
+        }
+    };
+
     const handleSubmit = (e) => {
         e.preventDefault()
         const card = {
             UserProfileId: loggedInUser.id,
-            CreditCardNumber:cardNumber,
+            CreditCardNumber:cardNumber.replace(/\s+/g, ''),
             CreditCardExpiration: cardExpiration
         }
         if(id){
@@ -53,10 +60,14 @@ export default function AddCardForm({loggedInUser})
                 <Label className="fw-bold">Card Number</Label>
                 <Cleave
                     value={cardNumber}
-                    options={{ creditCard: true }}
+                    options={{
+                        creditCard: false, // Disable automatic credit card detection
+                        blocks: [4, 4, 4, 4],
+                        delimiter: '-'
+                    }}
                     onChange={(e) => setCardNumber(e.target.rawValue)}
                     className="form-control"
-                    placeholder="1234 5678 9012 3456"
+                    placeholder="1234-5678-9012-3456"
                 />
             </FormGroup>
             <FormGroup>

--- a/client/src/components/Payment/AddCardForm.jsx
+++ b/client/src/components/Payment/AddCardForm.jsx
@@ -2,12 +2,13 @@ import { useEffect, useState } from "react";
 import { Button, Form, FormGroup, Input, Label } from "reactstrap";
 import { addNewCard, getByCardsId, updateCardDetails } from "../../managers/paymentDetailsManager.js";
 import { useNavigate, useParams } from "react-router-dom";
+import Cleave from "cleave.js/react";
 
 export default function AddCardForm({loggedInUser})
 {
     const {id} = useParams()
   
-    const [cardNumber, setCardNumber] = useState(0)
+    const [cardNumber, setCardNumber] = useState("")
     const [cardExpiration, setCardExpiration] = useState()
 
     const navigate = useNavigate()
@@ -50,9 +51,12 @@ export default function AddCardForm({loggedInUser})
         <Form className="w-50 m-auto mt-4" onSubmit={handleSubmit}>
             <FormGroup>
                 <Label className="fw-bold">Card Number</Label>
-                <Input 
-                    value={cardNumber} 
-                    onChange={(e) => {setCardNumber(e.target.value)}}
+                <Cleave
+                    value={cardNumber}
+                    options={{ creditCard: true }}
+                    onChange={(e) => setCardNumber(e.target.rawValue)}
+                    className="form-control"
+                    placeholder="1234 5678 9012 3456"
                 />
             </FormGroup>
             <FormGroup>

--- a/client/src/components/Payment/PaymentInfo.jsx
+++ b/client/src/components/Payment/PaymentInfo.jsx
@@ -42,6 +42,10 @@ export default function PaymentInfo({loggedInUser})
         setIsModalOpen(!isModalOpen)
     }
 
+    const formatCardNumber = (number) => {
+        return number.replace(/(\d{4})(?=\d)/g, '$1-');
+    };
+
     return(
     <div>
         <div className="d-flex justify-content-between align-items-center mt-2 mb-3 me-2">
@@ -64,7 +68,7 @@ export default function PaymentInfo({loggedInUser})
                     <tr key={p.id}>
                         <th scope="row">{index +1}</th>
                         <td>{p.userProfile.fullName}</td>
-                        <td>{p.creditCardNumber}</td>
+                        <td>{formatCardNumber(p.creditCardNumber)}</td>
                         <td>{p.formattedCreateDateTime}</td>
                         <td><Button color="primary" onClick={() => {navigate(`${p.id}`)}}>Edit</Button></td>
                         <td><Button color="danger" onClick={() => {openConfirmDeleteModal(p.id)}}>Remove</Button></td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "bootstrap": "^5.3.3",
+        "cleave.js": "^1.6.0",
         "react-router-dom": "^6.23.1",
         "react-toastify": "^10.0.5",
         "reactstrap": "^9.2.2"
@@ -61,6 +62,11 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+    },
+    "node_modules/cleave.js": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cleave.js/-/cleave.js-1.6.0.tgz",
+      "integrity": "sha512-ivqesy3j5hQVG3gywPfwKPbi/7ZSftY/UNp5uphnqjr25yI2CP8FS2ODQPzuLXXnNLi29e2+PgPkkiKUXLs/Nw=="
     },
     "node_modules/clsx": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "bootstrap": "^5.3.3",
+    "cleave.js": "^1.6.0",
     "react-router-dom": "^6.23.1",
     "react-toastify": "^10.0.5",
     "reactstrap": "^9.2.2"


### PR DESCRIPTION
### Purpose
To add logic to format a credit card correctly

### Files Changed 
- Added a cleave component to format the input field for adding a credit card in `AddCardForm.jsx`
- Added logic to render the card in the correct format in `PaymentDetails.jsx`

### Tetsing
Fetch, setup, and run according to the projects README, but do not create a new migrations
Confirm the following:
- As a user when adding a new payment option, it should only allow 16 digits and be formatted correctly
- When viewing your payment information. all of your payment options will be rendered in the correct format

Closes #32 